### PR TITLE
Added secret manager

### DIFF
--- a/backend/backend/getTickets/getTickets.py
+++ b/backend/backend/getTickets/getTickets.py
@@ -3,20 +3,24 @@ import boto3
 import requests
 from requests.auth import HTTPBasicAuth
 import os
-from dotenv import load_dotenv,find_dotenv
+from dotenv import load_dotenv
+
+def get_secret(secret_arn):
+    client = boto3.client("secretsmanager")
+    response = client.get_secret_value(SecretId=secret_arn)
+    secret = json.loads(response["SecretString"])
+    return secret
+
 
 def lambda_handler(event, context):
 
-    env_path=".env"
-    load_dotenv(dotenv_path=env_path)
-    
-    JIRA_API_TOKEN = os.getenv("JIRA_API_TOKEN")
-    JIRA_EMAIL = os.getenv("JIRA_EMAIL")
-    JIRA_URL=os.getenv("JIRA_URL")
-    
+    secret_arn = os.getenv("JIRA_SECRET_ARN")
+    secrets = get_secret(secret_arn)
+    JIRA_API_TOKEN = secrets["JIRA_API_TOKEN"]
+    JIRA_EMAIL = secrets["JIRA_EMAIL"]
+    JIRA_URL = secrets["JIRA_URL"]
     auth = HTTPBasicAuth(JIRA_EMAIL, JIRA_API_TOKEN)
   
-    
     try:
 
         response = requests.get(JIRA_URL, auth=auth)


### PR DESCRIPTION
Implemented the use of AWS Secrets Manager for securely storing and managing JIRA credentials. This functionality allows for the safe storage and retrieval of sensitive information such as API token, user email, and JIRA URL, which are used for interacting with the JIRA API.

What has been done:

1. Created an AWS Secrets Manager Secret:

    A JIRA_CREDENTIALS secret was created in AWS Secrets Manager. This secret stores the following key-value pairs:
    JIRA_API_TOKEN: The API token required for authenticating JIRA API requests.
    JIRA_EMAIL: The email address associated with the JIRA account.
    JIRA_URL: The base URL for accessing the JIRA API.

2. Configured Lambda Function to Access Secret:
  
    The Lambda function has been updated to retrieve the JIRA_CREDENTIALS secret from AWS Secrets Manager using the arn    
    The Lambda role was updated with the necessary permissions to read from Secrets Manager.